### PR TITLE
ISSUE-46: OCR language and better single Image sequencing

### DIFF
--- a/config/schema/strawberry_runners.schema.yml
+++ b/config/schema/strawberry_runners.schema.yml
@@ -87,6 +87,13 @@ strawberryfield_runners.strawberry_runners_postprocessor.ocr:
     mime_type:
       type: string
       label: 'Mimetypes(s) to limit this Processor to'
+    language_default:
+      type: string
+      label: 'The default language'
+      default: 'eng'
+    language_key:
+      type: bool
+      label: 'The JSON key(s) containing the language code in ISO639-3'
     arguments:
       type: string
       label: 'Any additional argument your executable binary requires'
@@ -102,21 +109,27 @@ strawberryfield_runners.strawberry_runners_postprocessor.ocr:
     arguments_djvu2hocr:
       type: string
       label: 'Any additional argument your executable binary requires'
+    arguments_pdfalto:
+      type: string
+      label: 'Any additional argument your executable binary requires'
     path:
       type: string
-      label: 'The path for he binary to execute'
+      label: 'The path for the binary to execute'
     path_tesseract:
       type: string
-      label: 'The path for he binary to execute'
+      label: 'The path for the binary to execute'
     path_pdf2djvu:
       type: string
-      label: 'The path for he binary to execute'
+      label: 'The path for the binary to execute'
     path_djvudump:
       type: string
-      label: 'The path for he binary to execute'
+      label: 'The path for the binary to execute'
     path_djvu2hocr:
       type: string
-      label: 'The path for he binary to execute'
+      label: 'The path for the binary to execute'
+    path_pdfalto:
+      type: string
+      label: 'The path for the pdfalto binary to execute'
     output_type:
       type: string
       label: 'The expected and desired output of this processor'

--- a/src/Ajax/UpdateCodeMirrorCommand.php
+++ b/src/Ajax/UpdateCodeMirrorCommand.php
@@ -48,6 +48,5 @@ class UpdateCodeMirrorCommand implements CommandInterface
       'content' => $this->content,
     ];
   }
-
 }
 

--- a/src/EventSubscriber/StrawberryRunnersEventInsertPostProcessingSubscriber.php
+++ b/src/EventSubscriber/StrawberryRunnersEventInsertPostProcessingSubscriber.php
@@ -263,6 +263,15 @@ class StrawberryRunnersEventInsertPostProcessingSubscriber extends Strawberryfie
                         $data->nuuid = $entity->uuid();
                         $data->field_name = $field_name;
                         $data->field_delta = $delta;
+                        // Get the configured Language from descriptive metadata
+                        if (isset($config['language_key']) && !empty($config['language_key']) && isset($flatvalues[$config['language_key']])) {
+                          $data->lang = is_array($flatvalues[$config['language_key']]) ? array_values($flatvalues[$config['language_key']]) : [$flatvalues[$config['language_key']]];
+                        }
+                        else {
+                          $data->lang = $config['language_default'] ?? NULL;
+                        }
+                        // Check if there is a key that forces processing.
+                        $force = isset($flatvalues["ap:tasks"]["ap:forcepost"]) ? (bool) $flatvalues["ap:tasks"]["ap:forcepost"] : FALSE;
 
                         // We are passing also the full file metadata.
                         // This gives us an advantage so we can reuse
@@ -284,7 +293,7 @@ class StrawberryRunnersEventInsertPostProcessingSubscriber extends Strawberryfie
                         // Or/ we can have a preSave Subscriber that reads the prop,
                         // sets the state and then removes if before saving
 
-                        $data->force = FALSE;
+                        $data->force = $force;
                         $data->plugin_config_entity_id = $activePluginId;
                         // See https://github.com/esmero/strawberry_runners/issues/10
                         // Since the destination Queue can be a modal thing

--- a/src/EventSubscriber/StrawberryRunnersEventSavePostProcessingSubscriber.php
+++ b/src/EventSubscriber/StrawberryRunnersEventSavePostProcessingSubscriber.php
@@ -263,6 +263,15 @@ class StrawberryRunnersEventSavePostProcessingSubscriber extends Strawberryfield
                         $data->nuuid = $entity->uuid();
                         $data->field_name = $field_name;
                         $data->field_delta = $delta;
+                        // Get the configured Language from descriptive metadata
+                        if (isset($config['language_key']) && !empty($config['language_key']) && isset($flatvalues[$config['language_key']])) {
+                          $data->lang = is_array($flatvalues[$config['language_key']]) ? array_values($flatvalues[$config['language_key']]) : [$flatvalues[$config['language_key']]];
+                        }
+                        else {
+                          $data->lang = $config['language_default'] ?? NULL;
+                        }
+                        // Check if there is a key that forces processing.
+                        $force = isset($flatvalues["ap:tasks"]["ap:forcepost"]) ? (bool) $flatvalues["ap:tasks"]["ap:forcepost"] : FALSE;
 
                         // We are passing also the full file metadata.
                         // This gives us an advantage so we can reuse
@@ -284,7 +293,7 @@ class StrawberryRunnersEventSavePostProcessingSubscriber extends Strawberryfield
                         // Or/ we can have a preSave Subscriber that reads the prop,
                         // sets the state and then removes if before saving
 
-                        $data->force = FALSE;
+                        $data->force = $force;
                         $data->plugin_config_entity_id = $activePluginId;
                         // See https://github.com/esmero/strawberry_runners/issues/10
                         // Since the destination Queue can be a modal thing

--- a/src/Form/strawberryRunnerPostprocessorEntityForm.php
+++ b/src/Form/strawberryRunnerPostprocessorEntityForm.php
@@ -8,6 +8,7 @@ use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginManager
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\strawberry_runners\Entity\strawberryRunnerPostprocessorEntity;
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Cache\Cache;
 
 /**
  * Builds the form to setup/create Strawberry Runner Processor config entities.
@@ -128,7 +129,8 @@ class strawberryRunnerPostprocessorEntityForm extends EntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $strawberry_processor = $this->entity;
-
+    $cache_id = "strawberry_runners:postprocessor:".$strawberry_processor->getPluginId();
+    Cache::invalidateTags([$cache_id]);
     $status = $strawberry_processor->save();
 
     switch ($status) {

--- a/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
@@ -590,25 +590,14 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
 
     $io = new stdClass();
     $input = new stdClass();
-
-    $input->{$input_property} = $data->{$input_property};
-
-    // By default, the input_argument value for a StrawberryRunnersPostProcessorPlugin::run() method is determined from the class annotation.
-    // E.g. "sequence_number" for the OcrPostProcessor class. Here we provide a mechanism for overriding that value.
-    // If in its configuration the plugin provides a "configured_input_argument", then this identifies the configuration field name that the user
-    // has edited to indicate which file metadata field contains the value of the input argument to pass into the processor's run method.
-    // For example, in the OcrPostProcessor, 'configured_input_argument' is configured as 'sequence_key'. In the settings form, the 'sequence_key' element
-    // is a text field where the user can enter the file metadata field name that contains the sequence number for the file on the object. This sequence number
-    // is fetched here and used in the run() method for the OcrPostProcessor.
-    // If no configured_input_argument is defined, then the input argument field defined in the plugin definition prevails.
-    $processor_config = $processor_instance->getConfiguration();
-    $configured_input_argument = $processor_config[$processor_config['configured_input_argument']] ?? NULL;
-    if($configured_input_argument && isset($data->metadata[$configured_input_argument])) {
-      $input->{$input_argument} = $data->metadata[$configured_input_argument];
+    if (isset($input_property)) {
+      $input->{$input_property} = $data->{$input_property};
     }
-    else {
+
+    if (isset($input_argument)) {
       $input->{$input_argument} = $data->{$input_argument} ?? 1;
     }
+
     // The Node UUID
     $input->nuuid = $data->nuuid;
     // All the rest of the associated Metadata in an as:structure

--- a/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
@@ -276,6 +276,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
           $toindex->where = $io->output->searchapi['where'] ?? [];
           $toindex->when = $io->output->searchapi['when'] ?? [];
           $toindex->ts = $io->output->searchapi['ts'] ?? NULL;
+          // Comes from WACZ Text one
           $toindex->uri = $io->output->searchapi['uri'] ?? NULL;
           $toindex->label = $io->output->searchapi['label'] ?? NULL;
           $toindex->sentiment = $io->output->searchapi['sentiment'] ?? 0;

--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -39,8 +39,6 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
     return [
         'source_type' => 'asstructure',
         'mime_type' => ['application/pdf'],
-        'configured_input_argument' => 'sequence_key',
-        'sequence_key' => 'sequence_id',
         'path' => '',
         'path_tesseract' => '',
         'path_pdfalto' => '',
@@ -102,20 +100,6 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       '#states' => [
         'visible' => [
           ':input[name="pluginconfig[source_type]"]' => ['value' => 'asstructure'],
-        ],
-      ],
-      '#required' => TRUE,
-    ];
-
-    $element['sequence_key'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Within the image file metadata, the JSON key that contains the sequence number.'),
-      '#default_value' => (!empty($this->getConfiguration()['sequence_key'])) ? $this->getConfiguration()['sequence_key'] : '',
-      '#states' => [
-        'visible' => [
-          ':input[name="pluginconfig[source_type]"]' => ['value' => 'asstructure'],
-          'and',
-          ':input[name="pluginconfig[jsonkey][as:image]"]' => ['checked' => TRUE],
         ],
       ],
       '#required' => TRUE,
@@ -420,7 +404,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
 
 
 
-            $nlp->spacy_entities($page_text, 'en_core_web_sm');
+            // $nlp->spacy_entities($page_text, 'en_core_web_sm');
             $spacy = $nlp->spacy_entities($page_text, 'en');
             $output->searchapi['sentiment'] = $nlp->sentiment($page_text, 'en');
             $output->searchapi['sentiment'] = is_scalar($output->searchapi['sentiment']) ? $output->searchapi['sentiment'] : NULL;

--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -8,10 +8,9 @@
 
 namespace Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessor;
 
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessor\SystemBinaryPostProcessor;
 use Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor;
-use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginBase;
 use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginInterface;
 use Drupal\strawberryfield\Plugin\search_api\datasource\StrawberryfieldFlavorDatasource;
 use Web64\Nlp\NlpClient;
@@ -41,20 +40,18 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
         'source_type' => 'asstructure',
         'mime_type' => ['application/pdf'],
         'configured_input_argument' => 'sequence_key',
-        'sequence_key' => 'sequence',
+        'sequence_key' => 'sequence_id',
         'path' => '',
         'path_tesseract' => '',
-        'path_pdf2djvu' => '',
-        'path_djvudump' => '',
-        'path_djvu2hocr' => '',
+        'path_pdfalto' => '',
         'arguments' => '',
         'arguments_tesseract' => '',
-        'arguments_pdf2djvu' => '',
-        'arguments_djvudump' => '',
-        'arguments_djvu2hocr' => '',
+        'arguments_pdfalto' => '',
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',
+        'language_key' => 'language_iso639_3',
+        'language_default' => 'eng',
         'timeout' => 300,
         'nlp' => TRUE,
         'nlp_url' => 'http://esmero-nlp:6400',
@@ -112,7 +109,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
 
     $element['sequence_key'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Within the image file metadata, the field that contains the sequence number.'),
+      '#title' => $this->t('Within the image file metadata, the JSON key that contains the sequence number.'),
       '#default_value' => (!empty($this->getConfiguration()['sequence_key'])) ? $this->getConfiguration()['sequence_key'] : '',
       '#states' => [
         'visible' => [
@@ -154,62 +151,57 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       '#required' => TRUE,
     ];
 
+    $element['language_key'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t("Within the ADO's metadata, the JSON key that contains the language in ISO639-3 (3 letter) format to be used for OCR/NLP processing via Tesseract."),
+      '#default_value' => (!empty($this->getConfiguration()['language_key'])) ? $this->getConfiguration()['language_key'] : '',
+      '#states' => [
+        'visible' => [
+          ':input[name="pluginconfig[source_type]"]' => ['value' => 'asstructure'],
+          'and',
+          ':input[name="pluginconfig[jsonkey][as:image]"]' => ['checked' => TRUE],
+        ],
+      ],
+      '#required' => TRUE,
+    ];
+
+    $element['language_default'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t("Please provide a default language in ISO639-3 (3 letter) format. If none is provided we will use 'eng' "),
+      '#default_value' => (!empty($this->getConfiguration()['language_default'])) ? $this->getConfiguration()['language_default'] : 'eng',
+      '#required' => TRUE,
+    ];
     $element['arguments_tesseract'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Any additional argument for your tesseract binary.'),
       '#default_value' => !empty($this->getConfiguration()['arguments_tesseract']) ? $this->getConfiguration()['arguments_tesseract'] : '%file',
-      '#description' => t('Any arguments your binary requires to run. Use %file as replacement for the file that is output by the GS binary.'),
+      '#description' => t('Any arguments your binary requires to run. Use %file as replacement for the file that is output by the GS binary. Use %language as replacement for the chosen languange'),
       '#required' => TRUE,
     ];
 
-    $element['path_pdf2djvu'] = [
+    $element['datafolder_tesseract'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('The system path to the pdf2djvu binary that will be executed by this processor.'),
-      '#default_value' => $this->getConfiguration()['path_pdf2djvu'],
-      '#description' => t('A full system path to the pdf2djvu binary present in the same environment your PHP runs, e.g  <em>/usr/bin/pdf2djvu</em>'),
+      '#title' => $this->t('The data/languages folder for Tesseract'),
+      '#default_value' => !empty($this->getConfiguration()['datafolder_tesseract']) ? $this->getConfiguration()['datafolder_tesseract'] : '/usr/share/tessdata',
+      '#description' => t('Absolute path where the Languages are stored in the Server. This will be used in --tessdata-dir'),
+      '#required' => TRUE,
+    ];
+
+    $element['path_pdfalto'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('The system path to the pdfalto binary that will be executed by this processor.'),
+      '#default_value' => $this->getConfiguration()['path_pdfalto'],
+      '#description' => t('A full system path to the pdfalto binary present in the same environment your PHP runs, e.g  <em>/usr/local/bin/pdfalto</em>'),
       '#required' => FALSE,
     ];
 
-    $element['arguments_pdf2djvu'] = [
+    $element['arguments_pdfalto'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Any additional argument for your pdf2djvu binary.'),
-      '#default_value' => !empty($this->getConfiguration()['arguments_pdf2djvu']) ? $this->getConfiguration()['arguments_pdf2djvu'] : '%file',
-      '#description' => t('Any arguments your binary requires to run. Use %file as replacement for the file that is output by the pdf2djvu binary.'),
+      '#title' => $this->t('Any additional argument for your pdfalto binary.'),
+      '#default_value' => !empty($this->getConfiguration()['arguments_pdfalto']) ? $this->getConfiguration()['arguments_pdfalto'] : '%file',
+      '#description' => t('Any arguments your binary requires to run. Use %file as replacement for the file that is output by the pdfalto binary.'),
       '#required' => FALSE,
     ];
-
-    $element['path_djvudump'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('The system path to the djvudump binary that will be executed by this processor.'),
-      '#default_value' => $this->getConfiguration()['path_djvudump'],
-      '#description' => t('A full system path to the djvudump binary present in the same environment your PHP runs, e.g  <em>/usr/bin/djvudump</em>'),
-      '#required' => FALSE,
-    ];
-
-    $element['arguments_djvudump'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Any additional argument for your djvudump binary.'),
-      '#default_value' => !empty($this->getConfiguration()['arguments_djvudump']) ? $this->getConfiguration()['arguments_djvudump'] : '%file',
-      '#description' => t('Any arguments your binary requires to run. Use %file as replacement for the file that is output by the djvudump binary.'),
-      '#required' => FALSE,
-    ];
-
-    $element['path_djvu2hocr'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('The system path to the djvu2hocr binary that will be executed by this processor.'),
-      '#default_value' => $this->getConfiguration()['path_djvu2hocr'],
-      '#description' => t('A full system path to the djvu2hocr binary present in the same environment your PHP runs, e.g  <em>/usr/bin/djvu2hocr</em>'),
-      '#required' => FALSE,
-    ];
-
-    $element['arguments_djvu2hocr'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Any additional argument for your djvu2hocr binary.'),
-      '#default_value' => !empty($this->getConfiguration()['arguments_djvu2hocr']) ? $this->getConfiguration()['arguments_djvu2hocr'] : '%file',
-      '#description' => t('Any arguments your binary requires to run. Use %file as replacement for the file that is output by the djvu2hocr binary.'),
-      '#required' => FALSE,
-    ];
-
 
     $element['output_type'] = [
       '#type' => 'select',
@@ -271,7 +263,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
         'polyglot' => 'Polyglot (faster)',
       ],
       '#default_value' => $this->getConfiguration()['nlp_method'],
-      '#description' => $this->t('The NER NLP method to use to extract Agents, Places and Sentiment'),
+      '#description' => $this->t('The NER NLP method to use to extract Agents, Places and Sentiment.'),
       '#states' => [
         'visible' => [
           ':input[name="pluginconfig[nlp]"]' => ['checked' => TRUE],
@@ -284,8 +276,8 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       '#title' => $this->t('Timeout in seconds for this process.'),
       '#default_value' => $this->getConfiguration()['timeout'],
       '#description' => $this->t('If the process runs out of time it can still be processed again.'),
-      '#size' => 3,
-      '#maxlength' => 3,
+      '#size' => 4,
+      '#maxlength' => 4,
       '#min' => 1,
     ];
     $element['weight'] = [
@@ -293,9 +285,9 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       '#title' => $this->t('Order or execution in the global chain.'),
       '#default_value' => $this->getConfiguration()['weight'],
     ];
-
     return $element;
   }
+
 
 
   public function onDependencyRemoval(array $dependencies) {
@@ -325,62 +317,36 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
     $input_argument = $this->pluginDefinition['input_argument'];
     $file_uuid = isset($io->input->metadata['dr:uuid']) ? $io->input->metadata['dr:uuid'] : NULL;
     $node_uuid = isset($io->input->nuuid) ? $io->input->nuuid : NULL;
+
     $config = $this->getConfiguration();
     $timeout = $config['timeout']; // in seconds
-
+    $file_languages = isset($io->input->lang) ? (array) $io->input->lang : [$config['language_default'] ? trim($config['language_default']) : 'eng'];
     if (isset($io->input->{$input_property}) && $file_uuid && $node_uuid) {
       $output = new \stdClass();
       // To be used by miniOCR as id in the form of {nodeuuid}/canvas/{fileuuid}/p{pagenumber}
       $sequence_number = isset($io->input->{$input_argument}) ? (int) $io->input->{$input_argument} : 1;
-
-      //check if PDF is searchable: has DJVU file the layer TXTz?
-      //pdf2djvu -q --no-metadata -p 2 -j0 -o page2.djv some_file.pdf && djvudump page2.djv |grep TXTz |wc -l
-      //
       setlocale(LC_CTYPE, 'en_US.UTF-8');
-      $execstring_check_searchable = $this->buildExecutableCommand_checkSearchable($io);
-      // assume its not there/won't work.
-      $proc_output_check_searchable = 0;
-      if ($execstring_check_searchable) {
-        $backup_locale = setlocale(LC_CTYPE, '0');
-        setlocale(LC_CTYPE, $backup_locale);
-        // Support UTF-8 commands.
-        // @see http://www.php.net/manual/en/function.shell-exec.php#85095
-        shell_exec("LANG=en_US.utf-8");
-        $proc_output_check_searchable = $this->proc_execute($execstring_check_searchable, $timeout);
-      }
-
-
-      if ($proc_output_check_searchable == 1) {
-
-        //if searchable run djvu2hocr
-        //
-        setlocale(LC_CTYPE, 'en_US.UTF-8');
-        $execstring_djvu2hocr = $this->buildExecutableCommand_djvu2hocr($io);
-        if ($execstring_djvu2hocr) {
+      $execstring_pdfalto = $this->buildExecutableCommand_pdfalto($io);
+      if ($execstring_pdfalto) {
           $backup_locale = setlocale(LC_CTYPE, '0');
           setlocale(LC_CTYPE, $backup_locale);
           // Support UTF-8 commands.
           // @see http://www.php.net/manual/en/function.shell-exec.php#85095
           shell_exec("LANG=en_US.utf-8");
-          $proc_output = $this->proc_execute($execstring_djvu2hocr, $timeout);
+          $proc_output = $this->proc_execute($execstring_pdfalto, $timeout);
           if (is_null($proc_output)) {
-            $this->logger->warning("DJVU processing via {$execstring_djvu2hocr} timed out");
-            throw new \Exception("Could not execute {$execstring_djvu2hocr} or timed out");
+            $this->logger->warning("PDFALTO processing via {$execstring_pdfalto} timed out");
+            throw new \Exception("Could not execute {$execstring_pdfalto} or timed out");
           }
-
-          //djvu2hocr output uses ocrx_line while tesseract uses ocr_line
-          //
-          $proc_output_mod = str_replace('ocrx_line', 'ocr_line', $proc_output);
-
-          $miniocr = $this->hOCRtoMiniOCR($proc_output_mod, $sequence_number);
-
-          $output->searchapi['fulltext'] = $miniocr;
-          $output->plugin = $miniocr;
-          $io->output = $output;
+          if (strpos($proc_output,"TextBlock")!== FALSE) {
+            $miniocr = $this->ALTOtoMiniOCR($proc_output, $sequence_number);
+            $output->searchapi['fulltext'] = $miniocr;
+            $output->plugin = $miniocr;
+            $io->output = $output;
         }
       }
-      else {
-        //if not searchable run tesseract
+      //if not searchable run tesseract
+      if (!isset($output->plugin)) {
         setlocale(LC_CTYPE, 'en_US.UTF-8');
         $execstring = $this->buildExecutableCommand($io);
         if ($execstring) {
@@ -391,7 +357,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
           shell_exec("LANG=en_US.utf-8");
           $proc_output = $this->proc_execute($execstring, $timeout);
           if (is_null($proc_output)) {
-            $this->logger->warning("HOCR processing via {$execstring} timed out");
+            $this->logger->warning("OCR processing via {$execstring} timed out");
             throw new \Exception("Could not execute {$execstring} or timed out");
           }
 
@@ -400,13 +366,35 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
           $output->plugin = $miniocr;
         }
       }
+
       // Lastly plain text version of the XML
-      $page_text = isset($output->searchapi['fulltext']) ? strip_tags(str_replace("<l>", PHP_EOL . "<l> ", $output->searchapi['fulltext'])) : '';
+      $page_text = isset($output->searchapi['fulltext']) ? strip_tags(str_replace("<l>",
+        PHP_EOL . "<l> ", $output->searchapi['fulltext'])) : '';
       $output->searchapi['metadata'] = [];
       // Check if NPL processing is enabled and if so do it.
-      if ($config['nlp'] && !empty($config['nlp_url']) && strlen(trim($page_text)) > 0 ) {
+      if ($config['nlp'] && !empty($config['nlp_url']) && strlen(trim($page_text)) > 0) {
         $nlp = new NlpClient($config['nlp_url']);
         if ($nlp) {
+          $languages_enabled = [];
+          $detected_lang = $nlp->language($page_text) ?? NULL;
+          $cache_id = "strawberry_runners:postprocessor:".$this->getPluginId();
+          $cached = $this->cacheBackend->get($cache_id);
+          if ($cached) {
+            $languages_enabled = $cached->data;
+          }
+          else {
+            $capabilities = $nlp->get_call('/status', NULL);
+            if ($capabilities && is_array($capabilities) && isset($capabilities['polyglot_lang_models']) && is_array($capabilities['polyglot_lang_models'])) {
+              $languages_enabled = array_keys($capabilities['polyglot_lang_models']);
+              $languages_enabled = array_map(function ($languages_enabled) {
+                $parts = explode(':', $languages_enabled);
+                return $parts[1] ?? NULL;
+              }, $languages_enabled);
+              $languages_enabled = array_filter($languages_enabled);
+              $this->cacheBackend->set($cache_id, $languages_enabled, CacheBackendInterface::CACHE_PERMANENT, [$cache_id]);
+            }
+          }
+
           if ($config['nlp_method'] == 'spacy') {
             /*
             PERSON:      People, including fictional.
@@ -428,29 +416,38 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
             ORDINAL:     “first”, “second”, etc.
             CARDINAL:    Numerals that do not fall under another type.
              */
-            $spacy = $nlp->spacy_entities($page_text ,'en');
-            $output->searchapi['sentiment'] = $nlp->sentiment($page_text , 'en');
+
+
+
+
+            $nlp->spacy_entities($page_text, 'en_core_web_sm');
+            $spacy = $nlp->spacy_entities($page_text, 'en');
+            $output->searchapi['sentiment'] = $nlp->sentiment($page_text, 'en');
             $output->searchapi['sentiment'] = is_scalar($output->searchapi['sentiment']) ? $output->searchapi['sentiment'] : NULL;
             $output->searchapi['where'] = array_unique(($spacy['GPE'] ?? []) + ($spacy['FAC'] ?? []));
             $output->searchapi['who'] = array_unique(($spacy['PERSON'] ?? []) + ($spacy['ORG'] ?? []));
             $output->searchapi['metadata'] = array_unique(($spacy['WORK_OF_ART'] ?? []) + ($spacy['EVENT'] ?? []));
           }
           elseif ($config['nlp_method'] == 'polyglot') {
-            $polyglot = $nlp->polyglot_entities($page_text, 'en');
-            $output->searchapi['where'] = $polyglot->getLocations();
-            $output->searchapi['who'] = array_unique(array_merge((array) $polyglot->getOrganizations(),
-              (array) $polyglot->getPersons()));
-            $output->searchapi['sentiment'] = $polyglot->getSentiment();
-            $entities_all = $polyglot->getEntities();
-            if (!empty($entities_all) and is_array($entities_all)) {
-              $output->searchapi['metadata'] = $entities_all;
+            if (in_array($detected_lang, $languages_enabled)) {
+              $polyglot = $nlp->polyglot_entities($page_text, $detected_lang);
+              $output->searchapi['where'] = $polyglot->getLocations();
+              $output->searchapi['who'] = array_unique(array_merge((array) $polyglot->getOrganizations(),
+                (array) $polyglot->getPersons()));
+              $output->searchapi['sentiment'] = $polyglot->getSentiment();
+              $entities_all = $polyglot->getEntities();
+              if (!empty($entities_all) and is_array($entities_all)) {
+                $output->searchapi['metadata'] = $entities_all;
+              }
             }
           }
+          $output->searchapi['nlplang'] = [$detected_lang];
         }
       }
       $output->searchapi['plaintext'] = $page_text;
+      $output->searchapi['processlang'] = $file_languages;
       $output->searchapi['ts'] = date("c");
-      $output->searchapi['label'] = $this->t("Sequence"). ' '. $sequence_number;
+      $output->searchapi['label'] = $this->t("Sequence") . ' ' . $sequence_number;
       $io->output = $output;
     }
     else {
@@ -480,74 +477,127 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
     $arguments_gs = $config['arguments'];
     $execpath_tesseract = $config['path_tesseract'];
     $arguments_tesseract = $config['arguments_tesseract'];
+    $datafolder_tesseract = $config['datafolder_tesseract'];
 
     if (empty($file_path)) {
       return NULL;
     }
-
     $command = '';
-    $can_run_gs = \Drupal::service('strawberryfield.utility')->verifyCommand($execpath_gs);
-    $can_run_tesseract = \Drupal::service('strawberryfield.utility')->verifyCommand($execpath_tesseract);
+    $can_run_gs = \Drupal::service('strawberryfield.utility')
+      ->verifyCommand($execpath_gs);
+    $can_run_tesseract = \Drupal::service('strawberryfield.utility')
+      ->verifyCommand($execpath_tesseract);
     $filename = pathinfo($file_path, PATHINFO_FILENAME);
     $sourcefolder = pathinfo($file_path, PATHINFO_DIRNAME);
     $sourcefolder = strlen($sourcefolder) > 0 ? $sourcefolder . '/' : sys_get_temp_dir() . '/';
     $file_mime = $io->input->metadata["dr:mimetype"] ?? NULL;
 
     // If we can't run tesseract, or have no mime type, we can't do anything.
-    if($file_mime && $can_run_tesseract) {
+    if ($file_mime && $can_run_tesseract) {
       $commands = [];
       // Check if this is a pdf. If so, attempt to convert to a png using ghostscript.
       //-- with r300 == 300dpi, should be configurable, etc. All should be configurable
       // E.g. gs -dBATCH -dNOPAUSE -sDEVICE=pnggray -r300 -dUseCropBox -sOutputFile=somepage_pagenumber.png %file
-      if($can_run_gs && $this->isGsMimeType($file_mime) && (strpos($arguments_gs, '%file') !== FALSE)) {
-          $tesseract_input_filename = "{$sourcefolder}{$filename}_{$sequence_number}.png";
-          $arguments_gs = "-dBATCH -dNOPAUSE -r300 -dUseCropBox -dQUIET -sDEVICE=pnggray -dFirstPage={$sequence_number} -dLastPage={$sequence_number} -sOutputFile=$tesseract_input_filename " . $arguments_gs;
-          $arguments_gs = str_replace('%s', '', $arguments_gs);
-          $arguments_gs = $this->strReplaceFirst('%file', '%s', $arguments_gs);
-          $arguments_gs = sprintf($arguments_gs, $file_path);
-          $commands[] = escapeshellcmd($execpath_gs . ' ' . $arguments_gs);
+      if ($can_run_gs && $this->isGsMimeType($file_mime) && (strpos($arguments_gs,
+            '%file') !== FALSE)) {
+        $tesseract_input_filename = "{$sourcefolder}{$filename}_{$sequence_number}.png";
+        $arguments_gs = "-dBATCH -dNOPAUSE -r300 -dUseCropBox -dQUIET -sDEVICE=pnggray -dFirstPage={$sequence_number} -dLastPage={$sequence_number} -sOutputFile=$tesseract_input_filename " . $arguments_gs;
+        $arguments_gs = str_replace('%s', '', $arguments_gs);
+        $arguments_gs = $this->strReplaceFirst('%file', '%s', $arguments_gs);
+        $arguments_gs = sprintf($arguments_gs, $file_path);
+        $commands[] = escapeshellcmd($execpath_gs . ' ' . $arguments_gs);
       }
 
-      elseif($this->isTesseractMimeType($file_mime) && $can_run_tesseract && (strpos($arguments_tesseract, '%file') !== FALSE)) {
+      elseif ($this->isTesseractMimeType($file_mime) && $can_run_tesseract && (strpos($arguments_tesseract,
+            '%file') !== FALSE)) {
         // Run tesseract directly on the file.
         $tesseract_input_filename = $file_path;
       }
 
-      if(!empty($tesseract_input_filename)) {
+      if (!empty($tesseract_input_filename)) {
+        if (strlen(trim($datafolder_tesseract))>0) {
+          $arguments_tesseract = ' --tessdata-dir ' . $datafolder_tesseract . ' ' . $arguments_tesseract;
+        }
         $arguments_tesseract = str_replace('%s', '', $arguments_tesseract);
-        $arguments_tesseract = $this->strReplaceFirst('%file', '%s', $arguments_tesseract);
-        $arguments_tesseract = sprintf($arguments_tesseract, $tesseract_input_filename);
+        $arguments_tesseract = str_replace('%d', '', $arguments_tesseract);
+        $arguments_tesseract = $this->strReplaceFirst('%file', '%s',
+          $arguments_tesseract);
+        $arguments_tesseract = $this->strReplaceFirst('%language', '%s',
+          $arguments_tesseract);
+        $file_languages = isset($io->input->lang) ? (array) $io->input->lang : ['eng'];
+        $this->areTesseractLanguages($execpath_tesseract, $datafolder_tesseract, $file_languages);
+        $file_languages_string = implode('+', $file_languages);
 
+        $arguments_tesseract = sprintf($arguments_tesseract,
+          $tesseract_input_filename, $file_languages_string);
         $commands[] = escapeshellcmd($execpath_tesseract . ' ' . $arguments_tesseract);
-        $command = implode( ' && ', $commands);
-
+        $command = implode(' && ', $commands);
       }
-      else {
-        // Absence of $tesseract_input_filename means no usable file was found.
-      }
-
-    }
-    else {
-      // Unable to run tesseract OCR. Not sure if to log this..
     }
     // Only return $command if it contains the original filepath somewhere
     if (strpos($command, $file_path) !== FALSE) {
       return $command;
     }
-    return '';
+    return NULL;
+  }
 
+  /**
+   * Builds a clean PDF Alto Command string using a File path.
+   *
+   * @param \stdClass $io
+   *    $io->input needs to contain
+   *           \Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor::$input_property
+   *           \Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor::$input_arguments
+   *    $io->output will contain the result of the processor
+   *
+   * @return null|string
+   */
+  protected function buildExecutableCommand_pdfalto(\stdClass $io) {
+    $input_property = $this->pluginDefinition['input_property'];
+    $input_argument = $this->pluginDefinition['input_argument'];
+    // Sets the default page to 1 if not passed.
+    $file_path = isset($io->input->{$input_property}) ? $io->input->{$input_property} : NULL;
+    $sequence_number = isset($io->input->{$input_argument}) ? (int) $io->input->{$input_argument} : 1;
+    $config = $this->getConfiguration();
+    $execpath_pdfalto = $config['path_pdfalto'];
+    $arguments_pdfalto = $config['arguments_pdfalto'];
+    $file_mime = $io->input->metadata["dr:mimetype"] ?? NULL;
+    if (empty($file_path)) {
+      return NULL;
+    }
+    // pdfalto -noLineNumbers -noImage -noImageInline -readingOrder -f 2 -l 2 %file -
+    $command = '';
+    $can_run_pdfalto = \Drupal::service('strawberryfield.utility')
+      ->verifyCommand($execpath_pdfalto);
+    if ($can_run_pdfalto &&
+      (strpos($arguments_pdfalto,
+          '%file') !== FALSE) && $this->isGsMimeType($file_mime)) {
+      $arguments_pdfalto = "-noLineNumbers -noImage -noImageInline -readingOrder -f {$sequence_number} -l {$sequence_number} " . $arguments_pdfalto . " - ";
+      $arguments_pdfalto = str_replace('%s', '', $arguments_pdfalto);
+      $arguments_pdfalto = $this->strReplaceFirst('%file', '%s',
+        $arguments_pdfalto);
+      $arguments_pdfalto = sprintf($arguments_pdfalto, $file_path);
+      $command_pdfalto = escapeshellcmd($execpath_pdfalto . ' ' . $arguments_pdfalto);
+      $command = $command_pdfalto;
+    }
+
+    // Only return $command if it contains the original filepath somewhere
+    if (strpos($command, $file_path) !== FALSE) {
+      return $command;
+    }
+    return NULL;
   }
 
   protected function hOCRtoMiniOCR($output, $pageid) {
-
     $hocr = simplexml_load_string($output);
     $internalErrors = libxml_use_internal_errors(TRUE);
     libxml_clear_errors();
     libxml_use_internal_errors($internalErrors);
     if (!$hocr) {
-      $this->logger->warning('Sorry for @pageid we could not decode/extract HOCR as XML', [
-        '@pageid' => $pageid,
-      ]);
+      $this->logger->warning('Sorry for @pageid we could not decode/extract HOCR as XML',
+        [
+          '@pageid' => $pageid,
+        ]);
       return NULL;
     }
     $miniocr = new \XMLWriter();
@@ -566,9 +616,10 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       }
       if ($pagetitle == NULL) {
         $miniocr->flush();
-        $this->logger->warning('Could not convert HOCR to MiniOCR for @pageid, no valid page dimensions found', [
-          '@pageid' => $pageid,
-        ]);
+        $this->logger->warning('Could not convert HOCR to MiniOCR for @pageid, no valid page dimensions found',
+          [
+            '@pageid' => $pageid,
+          ]);
         return NULL;
       }
       $coos = explode(" ", $pagetitle);
@@ -579,7 +630,8 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       if (count($coos)) {
         $miniocr->startElement("p");
         $miniocr->writeAttribute("xml:id", 'sequence_' . $pageid);
-        $miniocr->writeAttribute("wh", ltrim($pwidth, 0) . " " . ltrim($pheight, 0));
+        $miniocr->writeAttribute("wh",
+          ltrim($pwidth, 0) . " " . ltrim($pheight, 0));
         $miniocr->startElement("b");
         $page->registerXPathNamespace('ns', 'http://www.w3.org/1999/xhtml');
         foreach ($page->xpath('.//ns:span[@class="ocr_line"]') as $line) {
@@ -592,10 +644,10 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
               $y0 = (float) $wcoos[2];
               $x1 = (float) $wcoos[3];
               $y1 = (float) $wcoos[4];
-              $l = ltrim(sprintf('%.3f',($x0 / $pwidth)), 0);
-              $t = ltrim(sprintf('%.3f',($y0 / $pheight)), 0);
-              $w = ltrim(sprintf('%.3f',(($x1 - $x0) / $pwidth)), 0);
-              $h = ltrim(sprintf('%.3f',(($y1 - $y0) / $pheight)), 0);
+              $l = ltrim(sprintf('%.3f', ($x0 / $pwidth)), 0);
+              $t = ltrim(sprintf('%.3f', ($y0 / $pheight)), 0);
+              $w = ltrim(sprintf('%.3f', (($x1 - $x0) / $pwidth)), 0);
+              $h = ltrim(sprintf('%.3f', (($y1 - $y0) / $pheight)), 0);
               $text = (string) $word;
               if ($notFirstWord) {
                 $miniocr->text(' ');
@@ -604,7 +656,8 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
               // New OCR Highlight does not like empty <w> tags at all
               if (strlen(trim($text)) > 0) {
                 $miniocr->startElement("w");
-                $miniocr->writeAttribute("x", $l . ' ' . $t . ' ' . $w . ' ' . $h);
+                $miniocr->writeAttribute("x",
+                  $l . ' ' . $t . ' ' . $w . ' ' . $h);
                 $miniocr->text($text);
                 // Only assume we have at least one word for <w> tags
                 // Since lines? could end empty?
@@ -630,126 +683,75 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
     }
   }
 
-  /**
-   * Builds a clean Command string using a File path.
-   *
-   * @param \stdClass $io
-   *    $io->input needs to contain
-   *           \Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor::$input_property
-   *           \Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor::$input_arguments
-   *    $io->output will contain the result of the processor
-   *
-   * @return null|string
-   */
-  public function buildExecutableCommand_checkSearchable(\stdClass $io) {
-    $input_property = $this->pluginDefinition['input_property'];
-    $input_argument = $this->pluginDefinition['input_argument'];
-    // Sets the default page to 1 if not passed.
-    $file_path = isset($io->input->{$input_property}) ? $io->input->{$input_property} : NULL;
-    $sequence_number = isset($io->input->{$input_argument}) ? (int) $io->input->{$input_argument} : 1;
-    $config = $this->getConfiguration();
-    $execpath_pdf2djvu = $config['path_pdf2djvu'];
-    $arguments_pdf2djvu = $config['arguments_pdf2djvu'];
-    $execpath_djvudump = $config['path_djvudump'];
-    $arguments_djvudump = $config['arguments_djvudump'];
+  protected function ALTOtoMiniOCR($output, $pageid) {
+    $alto = simplexml_load_string($output);
+    $internalErrors = libxml_use_internal_errors(TRUE);
+    libxml_clear_errors();
+    libxml_use_internal_errors($internalErrors);
 
-    if (empty($file_path)) {
+    $miniocr = new \XMLWriter();
+    $miniocr->openMemory();
+    $miniocr->startDocument('1.0', 'UTF-8');
+    $miniocr->startElement("ocr");
+
+    if (!$alto) {
+      $this->logger->warning('Sorry for @pageid we could not decode/extract ALTO as XML',
+        [
+          '@pageid' => $pageid,
+        ]);
       return NULL;
     }
+    foreach ($alto->Layout->children() as $page) {
+      $pageWidthPts = (float) $page['WIDTH'];
+      $pageHeightPts = (float) $page['HEIGHT'];
+      // To check if conversion is ok px = pts / 72 * 300 (dpi)
+      //It seems that pdfalto output is in points while tesseract alto is in pixel
+      $pageWidthPx = sprintf('%.0f', $pageWidthPts * 300 / 72);
+      $pageHeightPx = sprintf('%.0f', $pageHeightPts * 300 / 72);
+      $miniocr->startElement("p");
+      $miniocr->writeAttribute("xml:id", 'sequence_' . $pageid);
+      $miniocr->writeAttribute("wh", $pageWidthPx . " " . $pageHeightPx);
 
-    // This run function executes a 2 step function
-    // First pdf2djvu -q --no-metadata -p 2 -j0 -o some_output_file.djv %file
-    // Second djvudump some_output_file.djv |grep TXTz |wc -l
+      $page->registerXPathNamespace('ns',
+        'http://www.loc.gov/standards/alto/ns-v3#');
+      foreach ($page->xpath('.//ns:TextBlock') as $block) {
+        $miniocr->startElement("b");
+        foreach ($block->children() as $line) {
+          $miniocr->startElement("l");
+          foreach ($line->children() as $child_name => $child_node) {
+            if ($child_name == 'SP') {
+              $miniocr->text(' ');
+            }
+            elseif ($child_name == 'String') {
+              // ALTO <String ID="p1_w1" CONTENT="Senato" HPOS="74.6078" VPOS="58.3326" WIDTH="31.9943" HEIGHT="10.0627" STYLEREFS="font0" />
+              //$miniocr->writeAttribute("x", $l . ' ' . $t . ' ' . $w . ' ' . $h);
+              $hpos_rel = (float) $child_node['HPOS'] / $pageWidthPts;
+              $vpos_rel = (float) $child_node['VPOS'] / $pageHeightPts;
+              $width_rel = (float) $child_node['WIDTH'] / $pageWidthPts;
+              $height_rel = (float) $child_node['HEIGHT'] / $pageHeightPts;
 
-    $command = '';
-    $can_run_pdf2djvu = \Drupal::service('strawberryfield.utility')
-      ->verifyCommand($execpath_pdf2djvu);
-    $can_run_djvudump = \Drupal::service('strawberryfield.utility')
-      ->verifyCommand($execpath_djvudump);
-    $filename = pathinfo($file_path, PATHINFO_FILENAME);
-    $sourcefolder = pathinfo($file_path, PATHINFO_DIRNAME);
-    $sourcefolder = strlen($sourcefolder) > 0 ? $sourcefolder . '/' : sys_get_temp_dir() . '/';
-    $pdf2djvu_destination_filename = "{$sourcefolder}{$filename}_{$sequence_number}.djv";
-    if ($can_run_pdf2djvu &&
-      $can_run_djvudump &&
-      (strpos($arguments_pdf2djvu, '%file') !== FALSE) &&
-      (strpos($arguments_djvudump, '%file') !== FALSE)) {
-      $arguments_pdf2djvu = "-q --no-metadata -j0 -p {$sequence_number} -o $pdf2djvu_destination_filename " . $arguments_pdf2djvu;
-      $arguments_pdf2djvu = str_replace('%s', '', $arguments_pdf2djvu);
-      $arguments_pdf2djvu = $this->strReplaceFirst('%file', '%s', $arguments_pdf2djvu);
-      $arguments_pdf2djvu = sprintf($arguments_pdf2djvu, $file_path);
+              $l = ltrim(sprintf('%.3f', $hpos_rel), 0);
+              $t = ltrim(sprintf('%.3f', $vpos_rel), 0);
+              $w = ltrim(sprintf('%.3f', $width_rel), 0);
+              $h = ltrim(sprintf('%.3f', $height_rel), 0);
 
-      $arguments_djvudump = str_replace('%s', '', $arguments_djvudump);
-      $arguments_djvudump = $this->strReplaceFirst('%file', '%s', $arguments_djvudump);
-      $arguments_djvudump = sprintf($arguments_djvudump, $pdf2djvu_destination_filename);
-
-      $command_pdf2djvu = escapeshellcmd($execpath_pdf2djvu . ' ' . $arguments_pdf2djvu);
-      $command_djvudump = escapeshellcmd($execpath_djvudump . ' ' . $arguments_djvudump);
-
-      $command = $command_pdf2djvu . ' && ' . $command_djvudump . ' |grep TXTz |wc -l';
-
+              $miniocr->startElement("w");
+              $miniocr->writeAttribute("x",
+                $l . ' ' . $t . ' ' . $w . ' ' . $h);
+              $miniocr->text($child_node['CONTENT']);
+              $miniocr->endElement();
+            }
+          }
+          $miniocr->endElement();
+        }
+        $miniocr->endElement();
+      }
+      $miniocr->endElement();
     }
-    else {
-      //"missing arguments for PDF2DJVU"
-    }
-    // Only return $command if it contains the original filepath somewhere
-    if (strpos($command, $file_path) !== FALSE) {
-      return $command;
-    }
-    return '';
-
-  }
-
-  /**
-   * Builds a clean Command string using a File path.
-   *
-   * @param \stdClass $io
-   *    $io->input needs to contain
-   *           \Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor::$input_property
-   *           \Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor::$input_arguments
-   *    $io->output will contain the result of the processor
-   *
-   * @return null|string
-   */
-  public function buildExecutableCommand_djvu2hocr(\stdClass $io) {
-    $input_property = $this->pluginDefinition['input_property'];
-    $input_argument = $this->pluginDefinition['input_argument'];
-    // Sets the default page to 1 if not passed.
-    $file_path = isset($io->input->{$input_property}) ? $io->input->{$input_property} : NULL;
-    $sequence_number = isset($io->input->{$input_argument}) ? (int) $io->input->{$input_argument} : 1;
-    $config = $this->getConfiguration();
-    $execpath_djvu2hocr = $config['path_djvu2hocr'];
-    $arguments_djvu2hocr = $config['arguments_djvu2hocr'];
-
-    if (empty($file_path)) {
-      return NULL;
-    }
-
-    // This run function executes a 1 step function
-    // First djvu2hocr some_output_file.djv
-    $command = '';
-    $can_run_djvu2hocr = \Drupal::service('strawberryfield.utility')
-      ->verifyCommand($execpath_djvu2hocr);
-    $filename = pathinfo($file_path, PATHINFO_FILENAME);
-    $sourcefolder = pathinfo($file_path, PATHINFO_DIRNAME);
-    $sourcefolder = strlen($sourcefolder) > 0 ? $sourcefolder . '/' : sys_get_temp_dir() . '/';
-    $pdf2djvu_destination_filename = "{$sourcefolder}{$filename}_{$sequence_number}.djv";
-    if ($can_run_djvu2hocr &&
-      (strpos($arguments_djvu2hocr, '%file') !== FALSE)) {
-
-      $arguments_djvu2hocr = str_replace('%s', '', $arguments_djvu2hocr);
-      $arguments_djvu2hocr = $this->strReplaceFirst('%file', '%s', $arguments_djvu2hocr);
-      $arguments_djvu2hocr = sprintf($arguments_djvu2hocr, $pdf2djvu_destination_filename);
-
-      $command_djvu2hocr = escapeshellcmd($execpath_djvu2hocr . ' ' . $arguments_djvu2hocr);
-
-      $command = $command_djvu2hocr;
-
-    }
-    else {
-      //"missing arguments for djvu 2 OCR");
-    }
-    return $command;
+    $miniocr->endElement();
+    $miniocr->endDocument();
+    unset($alto);
+    return $miniocr->outputMemory(TRUE);
   }
 
   // Mime types supported as input to Tesseract.
@@ -769,7 +771,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
     return in_array($mime_type, $tesseract_mime_types);
   }
 
-  // Mime types supported as input to Tesseract.
+  // Mime types supported as input to GS.
   // See https://github.com/tesseract-ocr/tessdoc/blob/main/InputFormats.md
   public function isGsMimeType($mime_type): bool {
     $gs_mime_types = [
@@ -777,6 +779,31 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       'application/x-pdf',
     ];
     return in_array($mime_type, $gs_mime_types);
+  }
+
+  protected function areTesseractLanguages($execpath_tesseract, $datafolder_tesseract, array $languages) {
+    if (\Drupal::service('strawberryfield.utility')
+      ->verifyCommand($execpath_tesseract)) {
+      // --tessdata-dir /usr/share/tessdata
+
+      if ($datafolder_tesseract && strlen(trim($datafolder_tesseract)) >0 ) {
+        $execpath_tesseract = $execpath_tesseract . ' --tessdata-dir '. escapeshellarg( $datafolder_tesseract);
+      }
+      $execpath_tesseract = $execpath_tesseract .' --list-langs';
+      $proc_output = NULL;
+      $proc_return = TRUE;
+      exec($execpath_tesseract, $proc_output, $proc_return);
+      if (is_array($proc_output) and count($proc_output)> 1 && !$proc_return) {
+        $proc_output = array_intersect($proc_output, $languages);
+      }
+      if (is_null($proc_output)) {
+        return [];
+      }
+      else {
+        return $proc_output;
+      }
+    }
+    return [];
   }
 
 }

--- a/src/Plugin/StrawberryRunnersPostProcessor/WaczPagesSequencePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/WaczPagesSequencePostProcessor.php
@@ -114,8 +114,8 @@ class WaczPagesSequencePostProcessor extends StrawberryRunnersPostProcessorPlugi
       '#title' => $this->t('Timeout in seconds for this process.'),
       '#default_value' => $this->getConfiguration()['timeout'],
       '#description' => $this->t('If the process runs out of time it can still be processed again.'),
-      '#size' => 3,
-      '#maxlength' => 3,
+      '#size' => 4,
+      '#maxlength' => 4,
       '#min' => 1,
     ];
     $element['weight'] = [

--- a/src/Plugin/StrawberryRunnersPostProcessorPluginBase.php
+++ b/src/Plugin/StrawberryRunnersPostProcessorPluginBase.php
@@ -8,6 +8,7 @@
 
 namespace Drupal\strawberry_runners\Plugin;
 
+use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -66,6 +67,13 @@ abstract class StrawberryRunnersPostProcessorPluginBase extends PluginBase imple
    */
   protected $logger;
 
+  /**
+   * The Cache Backend
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBackend;
+
   public function __construct(
     array $configuration,
     string $plugin_id,
@@ -75,7 +83,8 @@ abstract class StrawberryRunnersPostProcessorPluginBase extends PluginBase imple
     Client $httpClient,
     ConfigFactoryInterface $config_factory,
     FileSystemInterface $file_system,
-    LoggerInterface $logger
+    LoggerInterface $logger,
+    CacheBackendInterface $cache_backend
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeBundleInfo = $entityTypeBundleInfo;
@@ -88,10 +97,10 @@ abstract class StrawberryRunnersPostProcessorPluginBase extends PluginBase imple
     $this->fileSystem = $file_system;
     $this->temporary_directory = $this->fileSystem->getTempDirectory();
     $this->logger = $logger;
+    $this->cacheBackend = $cache_backend;
   }
 
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-
     return new static(
       $configuration,
       $plugin_id,
@@ -101,7 +110,8 @@ abstract class StrawberryRunnersPostProcessorPluginBase extends PluginBase imple
       $container->get('http_client'),
       $container->get('config.factory'),
       $container->get('file_system'),
-      $container->get('logger.channel.strawberry_runners')
+      $container->get('logger.channel.strawberry_runners'),
+      $container->get('cache.default'),
     );
   }
 

--- a/src/Plugin/StrawberryRunnersPostProcessorPluginBase.php
+++ b/src/Plugin/StrawberryRunnersPostProcessorPluginBase.php
@@ -129,8 +129,6 @@ abstract class StrawberryRunnersPostProcessorPluginBase extends PluginBase imple
       'weight' => 0,
       // The id of the config entity from where these values came from.
       'configEntity' => '',
-      // Optional definition of alternate input_argument source field from the configuration.
-      'configured_input_argument' => '',
     ];
   }
 


### PR DESCRIPTION
See [ #46](https://github.com/esmero/strawberry_runners/issues/46)

@patdunlavey this brings some changes to your open pull.

To test please use the following Docker containers:

`esmero/php-8.0-fpm:1.0.0-dev-multiarch` (for xdebug)
` esmero/php-8.0-fpm:1.0.0-multiarch` (for production)

And also please use https://github.com/esmero/strawberryfield/pull/218 (check if you feel that is OK for merging, if so we can merge right now) and go for 1.0.0 in general maybe before testing


docker exec -ti esmero-php bash -c "composer require strawberryfield/strawberryfield:1.0.0.x-dev strawberryfield/format_strawberryfield:1.0.0.x-dev strawberryfield/webform_strawberryfield:1.0.0.x-dev archipelago/ami:0.4.0.x-dev strawberryfield/strawberry_runners:0.4.0.x-dev"




Since new containers have 2x Tesseracts you want to change your settings on the OCR and the JSON Pager Post processors. Just noticed another tiny thing that needs removal and will update tomorrow more. But this works already. 
